### PR TITLE
fix(npdl): Add Last-Modified header on response

### DIFF
--- a/src/services/npdl.ts
+++ b/src/services/npdl.ts
@@ -36,6 +36,7 @@ npdl.get([
 		return;
 	}
 
+	response.setHeader('Last-Modified', new Date(Number(file.updated)).toUTCString());
 	readStream.pipe(response);
 });
 


### PR DESCRIPTION
This allows Express to return `304 Not Modified` when the console already has cached the requested BOSS file.