### PR TITLE
Hotfix: Set content-length for streamed responses 

### DIFF
--- a/src/services/npdi.ts
+++ b/src/services/npdi.ts
@@ -23,7 +23,7 @@ npdi.get('/p01/data/1/:bossAppId/:dataId/:fileHash', async (request, response) =
 		throw new Error('File not found in CDN');
 	}
 
-	return streamFileToResponse(response, fileStream, {
+	return streamFileToResponse(response, fileStream.stream, fileStream.size, {
 		// * The misspelling here is intentional, it's what the official server sets
 		'Content-Type': 'applicatoin/octet-stream',
 		'Content-Disposition': 'attachment',

--- a/src/services/npdl.ts
+++ b/src/services/npdl.ts
@@ -35,7 +35,7 @@ npdl.get([
 		return;
 	}
 
-	return streamFileToResponse(response, readStream, {
+	return streamFileToResponse(response, readStream.stream, readStream.size, {
 		'Last-Modified': new Date(Number(file.updated)).toUTCString()
 	});
 });


### PR DESCRIPTION
changes:
- Set content-length for streamed responses  (this prevents using transfer-encoding: chunked. which consoles seem to not support)