### PR TITLE
fix: Use hex as hash key, as base64 is not a valid filename

### DIFF
--- a/src/services/spr.ts
+++ b/src/services/spr.ts
@@ -181,7 +181,7 @@ spr.post('/relay/0', async (request, response) => {
 
 			// * Upload slot data
 			if (sprSlot.size > 0 && sprSlot.sendMode !== SendMode.RecvOnly) {
-				const dataHash = crypto.createHash('sha256').update(sprSlot.data).digest('base64');
+				const dataHash = crypto.createHash('sha256').update(sprSlot.data).digest('hex');
 				let slotData = await getDuplicateCECData(request.pid, sprSlot.gameID);
 
 				if (!slotData || slotData.data_hash !== dataHash) {


### PR DESCRIPTION
changes:
- use Hex as hash key

Base64 is not a valid filename for S3, R2 is very lenient but minio and aws are not.

SPR data would need to have to be cleared again, oops.
