### PR TITLE
Add ETag handling to stream based responses

### DIFF
--- a/src/services/npdl.ts
+++ b/src/services/npdl.ts
@@ -3,6 +3,7 @@ import { getTaskFile } from '@/database';
 import { config } from '@/config-manager';
 import { restrictHostnames } from '@/middleware/host-limit';
 import { getCDNFileAsStream, streamFileToResponse } from '@/cdn';
+import { handleEtag, sendEtagCacheResponse } from '@/util';
 
 const npdl = express.Router();
 
@@ -27,6 +28,11 @@ npdl.get([
 	if (!file) {
 		response.sendStatus(404);
 		return;
+	}
+
+	const { clientHasCached } = handleEtag(request, response, file.hash);
+	if (clientHasCached) {
+		return sendEtagCacheResponse(response);
 	}
 
 	const readStream = await getCDNFileAsStream('taskFile', file.file_key);

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ import type { AccountClient } from '@pretendonetwork/grpc/account/account_servic
 import type { GetNEXDataResponse } from '@pretendonetwork/grpc/account/get_nex_data_rpc';
 import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
 import type { GetUserFriendPIDsResponse } from '@pretendonetwork/grpc/friends/get_user_friend_pids_rpc';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import type { Stats } from 'node:fs';
 
 const gRPCAccountChannel = createChannel(`${config.grpc.account.address}:${config.grpc.account.port}`);
@@ -147,4 +147,17 @@ export async function getFriends(pid: number): Promise<GetUserFriendPIDsResponse
 		// TODO - Handle error
 		return null;
 	}
+}
+
+export function handleEtag(request: Request, response: Response, hash: string): { clientHasCached: boolean } {
+	const etag = `"${hash}"`;
+	response.setHeader('ETag', etag);
+	if (request.headers['if-none-match'] === etag) {
+		return { clientHasCached: true };
+	}
+	return { clientHasCached: false };
+}
+
+export function sendEtagCacheResponse(response: Response): void {
+	response.sendStatus(304).end();
 }


### PR DESCRIPTION
Changes:
- Add ETag handling to stream based responses

Express handles etags for almost all responses automatically (like tasksheets).
However because we hijack the response streams for piping cdn files, it can't properly handle ETags. Added manual handling of it for those endpoints

Resolves #37 (probably, I think it's redownloading because the lack of etags)
